### PR TITLE
Feat(i18n): add Portuguese (pt-BR) localization

### DIFF
--- a/extension/shared/package-lock.json
+++ b/extension/shared/package-lock.json
@@ -8,7 +8,9 @@
       "name": "opportunity-cost",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tooltip": "^1.2.7",
@@ -16,6 +18,8 @@
         "class-variance-authority": "^0.7.1",
         "cleave.js": "^1.6.0",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
+        "framer-motion": "^11.14.4",
         "lucide-react": "^0.511.0",
         "numeral": "^2.0.6",
         "react": "^19.1.0",
@@ -33,6 +37,8 @@
         "@types/react-dom": "^19.1.2",
         "@types/webextension-polyfill": "^0.10.7",
         "@vitejs/plugin-react": "^4.4.1",
+        "concurrently": "^8.2.2",
+        "cross-env": "^7.0.3",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
@@ -90,6 +96,7 @@
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -281,6 +288,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1201,6 +1218,114 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
@@ -1354,6 +1479,147 @@
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2346,6 +2612,7 @@
       "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2363,6 +2630,7 @@
       "integrity": "sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2373,6 +2641,7 @@
       "integrity": "sha512-WxYAszDYgsMV31OVyoG4jbAgJI1Gw0Xq9V19zwhy6+hUUJlJIdZ3r/cbdmTqFv++SktQkZ/X+46yGFxp5XJBEg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2430,6 +2699,7 @@
       "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.32.1",
         "@typescript-eslint/types": "8.32.1",
@@ -2653,6 +2923,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2685,6 +2956,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2818,6 +3099,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -2983,6 +3265,21 @@
       "integrity": "sha512-ivqesy3j5hQVG3gywPfwKPbi/7ZSftY/UNp5uphnqjr25yI2CP8FS2ODQPzuLXXnNLi29e2+PgPkkiKUXLs/Nw==",
       "license": "Apache-2.0"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2990,6 +3287,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color-convert": {
@@ -3018,6 +3331,50 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^14.13.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -3083,6 +3440,25 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3104,6 +3480,23 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -3183,6 +3576,13 @@
       "integrity": "sha512-xBOfg/EBaIlVsHipHl2VdTPJRSvErNUaqW8ejTq5OlOlIYx1wOllCHsAvAIrr55jD1IYEfdR86miUEt8H5IeJg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -3316,6 +3716,7 @@
       "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3529,6 +3930,7 @@
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3734,6 +4136,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -3790,6 +4219,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4031,6 +4470,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4424,6 +4873,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4587,6 +5043,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4888,6 +5359,7 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5069,6 +5541,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5078,6 +5551,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5174,6 +5648,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -5275,6 +5759,16 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -5390,6 +5884,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -5475,6 +5982,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -5483,6 +5996,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -5597,6 +6138,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5624,6 +6166,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5689,6 +6241,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5845,6 +6398,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5952,6 +6506,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5992,6 +6547,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5999,12 +6572,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -6025,6 +6637,7 @@
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extension/shared/src/components/index-page.tsx
+++ b/extension/shared/src/components/index-page.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState, useRef } from "react";
 import browser from "webextension-polyfill";
 import "@/index.css";
 import { SUPPORTED_CURRENCIES, DEFAULT_CURRENCY, APP_URL } from "../lib/constants";
+import { translations as enTranslations } from "../locales/en";
+import { translations as ptTranslations } from "../locales/pt";
 import { cn } from "@/lib/utils";
 import Cleave from "cleave.js/react";
 import { PriceDatabase } from "../lib/storage";
@@ -46,8 +48,15 @@ const SAYLOR_MODE_ACTIVATED_EVENT = "saylor-mode-activated";
 // Custom event for when Saylor Mode overlay completes
 const SAYLOR_MODE_COMPLETE_EVENT = "saylor-mode-complete";
 
+// --- i18n Helper ---
+const getTranslations = () => {
+  const lang = browser.i18n.getUILanguage();
+  return lang.startsWith("pt") ? ptTranslations : enTranslations;
+};
+const t = getTranslations();
+
 // --- Header ---
-function Header() {
+function Header({ t }: { t: typeof enTranslations }) {
   const [linkCopied, setLinkCopied] = useState(false);
 
   const handleCopyLink = () => {
@@ -62,7 +71,7 @@ function Header() {
     <header className="mb-4 flex items-center gap-x-0.5">
       <a href={APP_URL} target="_blank" className="mr-auto flex items-center">
         <img src="icons/logo.svg" alt="TFTC Logo" className="mr-2 h-8" />
-        <span className="text-foreground text-lg font-bold dark:text-white">Opportunity Cost</span>
+        <span className="text-foreground text-lg font-bold dark:text-white">{t.opportunityCost}</span>
       </a>
 
       <TooltipProvider>
@@ -76,17 +85,17 @@ function Header() {
               {linkCopied ? <Check className="size-4" /> : <Link className="size-4" />}
             </Button>
           </TooltipTrigger>
-          <TooltipContent>{linkCopied ? "Link copied" : "Copy link"}</TooltipContent>
+          <TooltipContent>{linkCopied ? t.linkCopied : t.copyLink}</TooltipContent>
         </Tooltip>
 
-        <Settings />
+        <Settings t={t} />
       </TooltipProvider>
     </header>
   );
 }
 
 // --- Live Price ---
-function LivePrice() {
+function LivePrice({ t }: { t: typeof enTranslations }) {
   const [prices, setPrices] = useState<Record<string, number>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -152,11 +161,11 @@ function LivePrice() {
   return (
     <section className="mb-4">
       <div className="flex flex-wrap items-start justify-between">
-        <span className="font-semibold dark:text-gray-200">Bitcoin Price:</span>
+        <span className="font-semibold dark:text-gray-200">{t.bitcoinPrice}</span>
         {loading ? (
-          <span className="font-mono text-lg text-gray-400 dark:text-gray-500">Loading...</span>
+          <span className="font-mono text-lg text-gray-400 dark:text-gray-500">{t.loading}</span>
         ) : error ? (
-          <span className="text-sm text-red-500">Error: {error}</span>
+          <span className="text-sm text-red-500">{t.error}: {error}</span>
         ) : (
           <div className="group flex items-center">
             {/* Currency switcher */}
@@ -164,7 +173,7 @@ function LivePrice() {
               <PopoverTrigger asChild>
                 <button
                   className="mr-1 rounded p-1 opacity-0 transition-opacity hover:bg-gray-100 focus:outline-none group-focus-within:opacity-100 group-hover:opacity-100 dark:hover:bg-gray-800"
-                  aria-label="Change default currency"
+                  aria-label={t.changeDefaultCurrency}
                   role="combobox"
                   aria-expanded={currencyPickerOpen}
                 >
@@ -173,9 +182,9 @@ function LivePrice() {
               </PopoverTrigger>
               <PopoverContent className="h-64 w-56 p-0">
                 <Command>
-                  <CommandInput placeholder="Search default currency..." />
+                  <CommandInput placeholder={t.searchDefaultCurrency} />
                   <CommandList>
-                    <CommandEmpty>No currency found.</CommandEmpty>
+                    <CommandEmpty>{t.noCurrencyFound}</CommandEmpty>
                     <CommandGroup>
                       {supportedCurrencies.map((c) => (
                         <CommandItem
@@ -208,7 +217,7 @@ function LivePrice() {
       </div>
       <div className="flex justify-end text-xs text-gray-400 dark:text-gray-500">
         <span>
-          Last updated:{" "}
+          {t.lastUpdated}:{" "}
           {lastUpdated ? lastUpdated.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" }) : "--:--"}
         </span>
       </div>
@@ -217,7 +226,7 @@ function LivePrice() {
 }
 
 // --- Converter ---
-function Converter() {
+function Converter({ t }: { t: typeof enTranslations }) {
   const [fiatAmount, setFiatAmount] = useState<string>("");
   const [btcAmount, setBtcAmount] = useState<string>("");
   const [lastEdited, setLastEdited] = useState<"fiat" | "btc">("fiat");
@@ -555,14 +564,14 @@ function Converter() {
 
   // List of available denominations
   const denominations = [
-    { value: "sats", label: "Satoshis (sats)" },
-    { value: "btc", label: "Bitcoin (BTC)" },
+    { value: "sats", label: t.satoshis },
+    { value: "btc", label: t.bitcoinUnit },
   ];
 
   return (
     <section className="mb-4">
       <div>
-        <div className="mb-2 text-sm font-bold dark:text-gray-200">Currency Converter</div>
+        <div className="mb-2 text-sm font-bold dark:text-gray-200">{t.currencyConverter}</div>
 
         <div
           className={cn(
@@ -585,7 +594,7 @@ function Converter() {
               htmlFor="fiat-input"
               className="text-md pointer-events-none font-medium text-gray-800 dark:text-gray-200"
             >
-              Fiat
+              {t.fiat}
             </label>
             <select
               className="text-right text-xs dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
@@ -653,7 +662,7 @@ function Converter() {
                   : "pointer-events-none translate-y-0 opacity-0",
               )}
             >
-              {lastEdited === "fiat" ? "Converting Fiat to Bitcoin" : "Converting Bitcoin to Fiat"}
+              {lastEdited === "fiat" ? t.convertingFiatToBtc : t.convertingBtcToFiat}
             </div>
           </div>
         </div>
@@ -680,7 +689,7 @@ function Converter() {
               htmlFor="btc-input"
               className="text-md pointer-events-none font-medium text-gray-800 dark:text-gray-200"
             >
-              Bitcoin
+              {t.bitcoin}
             </label>
             <select
               id="denomination-select"
@@ -737,7 +746,7 @@ function Converter() {
 }
 
 // --- Settings ---
-function Settings() {
+function Settings({ t }: { t: typeof enTranslations }) {
   const [showSettings, setShowSettings] = useState(false);
   const [denomination, setDenomination] = useState<"sats" | "btc">("btc");
   const [displayMode, setDisplayMode] = useState<"bitcoin-only" | "dual-display">("dual-display");
@@ -908,7 +917,7 @@ function Settings() {
 
   return (
     <DropdownMenu open={showSettings} onOpenChange={setShowSettings}>
-      <DropdownMenuTrigger asChild>
+      <DropdownMenuTrigger asChild aria-label={t.settings}>
         <Button
           variant="ghost"
           className="size-8 rounded p-0 hover:bg-gray-100 focus:outline-none dark:hover:bg-gray-800"
@@ -918,7 +927,7 @@ function Settings() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-48" align="end">
-        <DropdownMenuLabel>Display</DropdownMenuLabel>
+        <DropdownMenuLabel>{t.display}</DropdownMenuLabel>
         <DropdownMenuCheckboxItem
           onSelect={(e) => e.preventDefault()}
           checked={displayMode === "bitcoin-only"}
@@ -927,7 +936,7 @@ function Settings() {
         >
           <span className="flex items-center">
             <Bitcoin className={cn("mr-2 h-4 w-4", displayMode === "bitcoin-only" && "text-oc-primary")} />
-            <span className="text-primary">Bitcoin-only Mode</span>
+            <span className="text-primary">{t.bitcoinOnlyMode}</span>
           </span>
         </DropdownMenuCheckboxItem>
         <Tooltip delayDuration={500}>
@@ -941,16 +950,14 @@ function Settings() {
               >
                 <span className="flex items-center">
                   <PaintbrushVertical className={cn("mr-2 h-4 w-4", highlightBitcoinValue && "text-oc-primary")} />
-                  <span className={cn("text-primary", isHighlightMandatory && "opacity-75")}>Highlight Bitcoin</span>
+                  <span className={cn("text-primary", isHighlightMandatory && "opacity-75")}>{t.highlightBitcoin}</span>
                 </span>
               </DropdownMenuCheckboxItem>
             </div>
           </TooltipTrigger>
           {isHighlightMandatory && (
             <TooltipContent>
-              Automatically enabled when Saylor Mode
-              <br />
-              and Bitcoin-only mode are both active
+              {t.saylorModeTooltip}
             </TooltipContent>
           )}
         </Tooltip>
@@ -966,7 +973,7 @@ function Settings() {
               alt="Michael Saylor"
               className={cn("mr-2 h-4 w-4 rounded-full object-cover", saylorMode && "ring-oc-primary/50 ring-2")}
             />
-            <span className="text-primary">Saylor Mode ⚡</span>
+            <span className="text-primary">{t.saylorMode}</span>
           </span>
         </DropdownMenuCheckboxItem>
         {saylorMode && (
@@ -976,14 +983,14 @@ function Settings() {
           >
             <a className="flex items-center" href={`${APP_URL}/saylor-mode`} target="_blank">
               <Info className="mr-1 size-3" />
-              What is Saylor Mode?
+              {t.whatIsSaylorMode}
             </a>
           </DropdownMenuItem>
         )}
         {!saylorMode && (
           <>
             <DropdownMenuSeparator />
-            <DropdownMenuLabel>Denomination</DropdownMenuLabel>
+            <DropdownMenuLabel>{t.denomination}</DropdownMenuLabel>
             <DropdownMenuRadioGroup
               value={denomination}
               onValueChange={(value) => handleDenominationChange(value as "sats" | "btc")}
@@ -993,23 +1000,23 @@ function Settings() {
                 value="sats"
                 className="data-[state=checked]:text-oc-primary"
               >
-                Sats
+                {t.sats.charAt(0).toUpperCase() + t.sats.slice(1)}
               </DropdownMenuRadioItem>
               <DropdownMenuRadioItem
                 onSelect={(e) => e.preventDefault()}
                 value="btc"
                 className="data-[state=checked]:text-oc-primary"
               >
-                BTC
+                {t.btc}
               </DropdownMenuRadioItem>
               <Tooltip delayDuration={500}>
-                <TooltipContent>Shows BTC for prices &ge;0.01 BTC, sats otherwise.</TooltipContent>
+                <TooltipContent>{t.dynamicBtcSatsTooltip}</TooltipContent>
                 <DropdownMenuRadioItem
                   onSelect={(e) => e.preventDefault()}
                   value="dynamic"
                   className="data-[state=checked]:text-oc-primary gap-0"
                 >
-                  Dynamic BTC/Sats
+                  {t.dynamic}
                   <TooltipTrigger className="ml-auto">
                     <Info className="ml-auto size-3" />
                   </TooltipTrigger>
@@ -1024,7 +1031,7 @@ function Settings() {
         <DropdownMenuGroup>
           <DropdownMenuItem asChild className="flex items-center justify-between">
             <a href="options.html" target="_blank" rel="noopener noreferrer">
-              Settings
+                {t.advancedSettings}
               <Settings2 className="ml-auto h-4 w-4" />
             </a>
           </DropdownMenuItem>
@@ -1035,7 +1042,7 @@ function Settings() {
 }
 
 // --- Call To Action ---
-function CallToAction() {
+function CallToAction({ t }: { t: typeof enTranslations }) {
   const [themeMode, setThemeMode] = useState<"system" | "light" | "dark">("system");
 
   // Get system theme detection function
@@ -1117,7 +1124,7 @@ function CallToAction() {
             target="_blank"
             rel="noopener noreferrer"
           >
-            Subscribe to Bitcoin Brief
+            {t.subscribeToBitcoinBrief}
           </a>
         </Button>
 
@@ -1126,21 +1133,21 @@ function CallToAction() {
           <button
             onClick={() => handleThemeChange("light")}
             className={`rounded-full p-1 hover:bg-gray-100 dark:hover:bg-gray-800 ${themeMode === "light" ? "bg-gray-200 dark:bg-gray-700" : ""}`}
-            title="Light Mode"
+            title={t.lightMode}
           >
             <Sun className="h-4 w-4" />
           </button>
           <button
             onClick={() => handleThemeChange("system")}
             className={`rounded-full p-1 hover:bg-gray-100 dark:hover:bg-gray-800 ${themeMode === "system" ? "bg-gray-200 dark:bg-gray-700" : ""}`}
-            title="System Default"
+            title={t.systemDefault}
           >
             <Monitor className="h-4 w-4" />
           </button>
           <button
             onClick={() => handleThemeChange("dark")}
             className={`rounded-full p-1 hover:bg-gray-100 dark:hover:bg-gray-800 ${themeMode === "dark" ? "bg-gray-200 dark:bg-gray-700" : ""}`}
-            title="Dark Mode"
+            title={t.darkMode}
           >
             <Moon className="h-4 w-4" />
           </button>
@@ -1159,6 +1166,7 @@ function Footer({
   isSiteEnabled: boolean | null;
   onToggle: () => void;
   hostname: string;
+  t: typeof enTranslations;
 }) {
   return (
     <footer className="flex items-center justify-between text-left text-xs text-gray-400 dark:text-gray-500">
@@ -1169,7 +1177,7 @@ function Footer({
               <Switch id="extension-enabled" checked={isSiteEnabled} onCheckedChange={onToggle} />
             )}
             <label htmlFor="extension-enabled" className="cursor-pointer text-xs">
-              {isSiteEnabled ? "Enabled" : "Disabled"} on this site
+              {isSiteEnabled ? t.enabledOnThisSite : t.disabledOnThisSite}
             </label>
           </>
         )}
@@ -1182,7 +1190,7 @@ function Footer({
             rel="noopener noreferrer"
             className="hover:underline"
           >
-            Privacy
+            {t.privacy}
           </a>{" "}
           &middot;{" "}
           <a
@@ -1191,7 +1199,7 @@ function Footer({
             rel="noopener noreferrer"
             className="hover:underline"
           >
-            Feedback
+            {t.feedback}
           </a>
         </span>
       </div>
@@ -1349,13 +1357,14 @@ export function IndexPage() {
 
   return (
     <div className="min-h-screen w-80 bg-white p-4 font-sans dark:bg-gray-900 dark:text-white">
-      <Header />
-      <LivePrice />
-      <Converter />
-      <CallToAction />
-      <Footer isSiteEnabled={isSiteEnabled} onToggle={toggleCurrentSite} hostname={hostname} />
+      <Header t={t} />
+      <LivePrice t={t} />
+      <Converter t={t} />
+      <CallToAction t={t} />
+      <Footer isSiteEnabled={isSiteEnabled} onToggle={toggleCurrentSite} hostname={hostname} t={t} />
       <SaylorModeOverlay
         isActive={showSaylorAnimation}
+        t={t}
         onComplete={() => {
           setShowSaylorAnimation(false);
           // Dispatch event to reopen settings dropdown

--- a/extension/shared/src/components/options-page.tsx
+++ b/extension/shared/src/components/options-page.tsx
@@ -1,10 +1,18 @@
 import { useEffect, useState } from "react";
 import browser from "webextension-polyfill";
 import { PriceDatabase } from "../lib/storage";
+import { translations as enTranslations } from "../locales/en";
+import { translations as ptTranslations } from "../locales/pt";
 import { DEFAULT_CURRENCY, SUPPORTED_CURRENCIES } from "../lib/constants";
 import { Button } from "./ui/button";
 import { Tooltip, TooltipContent } from "./ui/tooltip";
 import { X } from "lucide-react";
+
+// --- i18n Helper ---
+const getTranslations = () => {
+  const lang = browser.i18n.getUILanguage();
+  return lang.startsWith("pt") ? ptTranslations : enTranslations;
+};
 
 // Theme types for more flexibility
 type ThemeMode = "system" | "light" | "dark";
@@ -23,6 +31,9 @@ export function OptionsPage() {
   const [saveMessage, setSaveMessage] = useState(false);
   const [loadingSettings, setLoadingSettings] = useState(true);
   const [settingsError, setSettingsError] = useState<string | null>(null);
+
+  // Get translations
+  const t = getTranslations();
 
   // Compute if highlight bitcoin should be mandatory
   const isHighlightMandatory = saylorMode && displayMode === "bitcoin-only";
@@ -191,14 +202,14 @@ export function OptionsPage() {
     >
       <div className="mb-6 flex items-center">
         <img src="icons/logo.svg" alt="TFTC Logo" className="mr-3 h-8" />
-        <h1 className="text-xl font-bold text-gray-900 dark:text-white">Settings</h1>
+        <h1 className="text-xl font-bold text-gray-900 dark:text-white">{t.optionsTitle}</h1>
       </div>
 
       <div className="space-y-6">
         {/* Main Settings */}
         <div className="rounded-lg bg-white p-6 shadow-sm dark:bg-gray-800">
           {loadingSettings ? (
-            <div className="text-gray-400 dark:text-gray-500">Loading...</div>
+            <div className="text-gray-400 dark:text-gray-500">{t.loadingOptions}</div>
           ) : settingsError ? (
             <div className="text-red-500">{settingsError}</div>
           ) : (
@@ -209,7 +220,7 @@ export function OptionsPage() {
                     htmlFor="default-currency"
                     className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
                   >
-                    Default Currency
+                    {t.defaultCurrencyLabel}
                   </label>
                   <select
                     id="default-currency"
@@ -230,7 +241,7 @@ export function OptionsPage() {
                     htmlFor="denomination"
                     className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
                   >
-                    Bitcoin Unit
+                    {t.bitcoinUnitLabel}
                   </label>
                   <select
                     id="denomination"
@@ -238,9 +249,9 @@ export function OptionsPage() {
                     value={denomination}
                     onChange={(e) => setDenomination(e.target.value as "btc" | "sats" | "dynamic")}
                   >
-                    <option value="sats">Satoshis</option>
-                    <option value="btc">Bitcoin</option>
-                    <option value="dynamic">Dynamic</option>
+                    <option value="sats">{t.satsOption}</option>
+                    <option value="btc">{t.btcOption}</option>
+                    <option value="dynamic">{t.dynamicOption}</option>
                   </select>
                 </div>
 
@@ -249,7 +260,7 @@ export function OptionsPage() {
                     htmlFor="display-mode"
                     className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
                   >
-                    Display Mode
+                    {t.displayModeLabel}
                   </label>
                   <select
                     id="display-mode"
@@ -257,8 +268,8 @@ export function OptionsPage() {
                     value={displayMode}
                     onChange={(e) => setDisplayMode(e.target.value as "bitcoin-only" | "dual-display")}
                   >
-                    <option value="dual-display">Dual Display</option>
-                    <option value="bitcoin-only">Bitcoin Only</option>
+                    <option value="dual-display">{t.dualDisplayOption}</option>
+                    <option value="bitcoin-only">{t.bitcoinOnlyOption}</option>
                   </select>
                 </div>
 
@@ -267,7 +278,7 @@ export function OptionsPage() {
                     htmlFor="theme-mode"
                     className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
                   >
-                    Theme
+                    {t.themeLabel}
                   </label>
                   <select
                     id="theme-mode"
@@ -275,9 +286,9 @@ export function OptionsPage() {
                     value={themeMode}
                     onChange={(e) => handleThemeChange(e.target.value as ThemeMode)}
                   >
-                    <option value="system">System</option>
-                    <option value="light">Light</option>
-                    <option value="dark">Dark</option>
+                    <option value="system">{t.systemOption}</option>
+                    <option value="light">{t.lightOption}</option>
+                    <option value="dark">{t.darkOption}</option>
                   </select>
                 </div>
               </div>
@@ -290,7 +301,7 @@ export function OptionsPage() {
                     onChange={(e) => setSaylorMode(e.target.checked)}
                     className="mr-2 rounded"
                   />
-                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Saylor Mode ⚡</span>
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{t.saylorMode}</span>
                 </label>
 
                 <label className="flex items-center">
@@ -305,22 +316,22 @@ export function OptionsPage() {
                     className="mr-2 rounded"
                   />
                   <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                    Highlight Bitcoin values
+                    {t.highlightBitcoinLabel}
                     {isHighlightMandatory && <span className="ml-1 text-xs text-orange-500">*</span>}
                   </span>
                 </label>
                 {isHighlightMandatory && (
                   <p className="ml-6 text-xs text-orange-600 dark:text-orange-400">
-                    * Auto-enabled with Saylor Mode + Bitcoin-only
+                    {t.highlightMandatoryTooltip}
                   </p>
                 )}
               </div>
 
               <div className="flex items-center justify-between pt-4">
                 <Button type="submit" variant="default">
-                  Save Settings
+                  {t.saveButton}
                 </Button>
-                {saveMessage && <span className="text-sm font-medium text-green-600 dark:text-green-400">Saved!</span>}
+                {saveMessage && <span className="text-sm font-medium text-green-600 dark:text-green-400">{t.saveSuccess}</span>}
               </div>
             </form>
           )}
@@ -328,7 +339,7 @@ export function OptionsPage() {
 
         {/* Disabled Sites */}
         <div className="rounded-lg bg-white p-6 shadow-sm dark:bg-gray-800">
-          <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Disabled Sites</h2>
+          <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">{t.disabledSitesTitle}</h2>
 
           <form onSubmit={handleAddDisabledSite} className="mb-4 flex gap-2">
             <input
@@ -339,12 +350,12 @@ export function OptionsPage() {
               className="flex-1 rounded border border-gray-300 p-2 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             />
             <Button type="submit" variant="secondary" size="sm">
-              Add
+              {t.addSiteButton}
             </Button>
           </form>
 
           {disabledSites.length === 0 ? (
-            <p className="text-center text-sm text-gray-500 dark:text-gray-400">No disabled sites</p>
+            <p className="text-center text-sm text-gray-500 dark:text-gray-400">{t.noDisabledSites}</p>
           ) : (
             <div className="space-y-2">
               {disabledSites.map((site) => (
@@ -366,9 +377,9 @@ export function OptionsPage() {
 
         {/* Newsletter */}
         <div className="rounded-lg bg-orange-50 p-6 text-center dark:bg-gray-800">
-          <h3 className="mb-2 font-semibold text-gray-900 dark:text-white">Bitcoin Brief Newsletter</h3>
+          <h3 className="mb-2 font-semibold text-gray-900 dark:text-white">{t.newsletterTitle}</h3>
           <p className="mb-4 text-sm text-gray-600 dark:text-gray-300">
-            Get Bitcoin updates and market insights from TFTC.
+            {t.newsletterDescription}
           </p>
           <Button variant="default" asChild>
             <a
@@ -376,7 +387,7 @@ export function OptionsPage() {
               target="_blank"
               rel="noopener noreferrer"
             >
-              Subscribe
+              {t.subscribeButton}
             </a>
           </Button>
         </div>
@@ -392,7 +403,7 @@ export function OptionsPage() {
             rel="noopener noreferrer"
             className="hover:underline"
           >
-            Privacy
+            {t.privacy}
           </a>{" "}
           &middot;{" "}
           <a
@@ -401,7 +412,7 @@ export function OptionsPage() {
             rel="noopener noreferrer"
             className="hover:underline"
           >
-            Feedback
+            {t.feedback}
           </a>
         </p>
       </div>

--- a/extension/shared/src/components/saylor-mode-overlay.tsx
+++ b/extension/shared/src/components/saylor-mode-overlay.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { translations as enTranslations } from "../locales/en";
 import { APP_URL } from "@/lib/constants";
 
 // Animation Constants
@@ -33,9 +34,10 @@ const SUBTITLE_GLOW_BLUR = "8px"; // Subtitle glow blur radius
 interface SaylorModeOverlayProps {
   isActive: boolean;
   onComplete: () => void;
+  t: typeof enTranslations;
 }
 
-export function SaylorModeOverlay({ isActive, onComplete }: SaylorModeOverlayProps) {
+export function SaylorModeOverlay({ isActive, onComplete, t }: SaylorModeOverlayProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationStartTime = useRef<number>(0);
 
@@ -188,7 +190,7 @@ export function SaylorModeOverlay({ isActive, onComplete }: SaylorModeOverlayPro
               animate={{ y: 0 }}
               transition={{ delay: TITLE_SLIDE_DELAY, duration: TITLE_SLIDE_DURATION }}
             >
-              SAYLOR MODE
+              {t.saylorModeTitle}
             </motion.h1>
 
             <motion.div
@@ -206,7 +208,7 @@ export function SaylorModeOverlay({ isActive, onComplete }: SaylorModeOverlayPro
                   textShadow: `0 0 ${SUBTITLE_GLOW_BLUR} ${BITCOIN_ORANGE}`,
                 }}
               >
-                Reprices everything for $21M per bitcoin
+                {t.saylorModeSubtitle}
               </p>
             </motion.div>
 
@@ -230,7 +232,7 @@ export function SaylorModeOverlay({ isActive, onComplete }: SaylorModeOverlayPro
                 animate={{ pointerEvents: "auto" }}
                 transition={{ delay: QUOTE_FADE_DELAY + QUOTE_FADE_DURATION }}
               >
-                Learn more
+                {t.learnMore}
               </motion.a>
             </motion.div>
 
@@ -253,7 +255,7 @@ export function SaylorModeOverlay({ isActive, onComplete }: SaylorModeOverlayPro
               }}
               whileTap={{ scale: 0.95 }}
             >
-              CONTINUE
+              {t.continue}
             </motion.button>
           </motion.div>
         </motion.div>

--- a/extension/shared/src/lib/storage.ts
+++ b/extension/shared/src/lib/storage.ts
@@ -1,5 +1,3 @@
-/// <reference types="chrome" />
-
 import browser from "webextension-polyfill";
 
 /**

--- a/extension/shared/src/locales/en.ts
+++ b/extension/shared/src/locales/en.ts
@@ -1,0 +1,83 @@
+export const translations = {
+  // Header
+  opportunityCost: "Opportunity Cost",
+  linkCopied: "Link copied",
+  copyLink: "Copy link",
+
+  // Live Price
+  bitcoinPrice: "Bitcoin Price:",
+  loading: "Loading...",
+  error: "Error",
+  lastUpdated: "Last updated",
+  changeDefaultCurrency: "Change default currency",
+  searchDefaultCurrency: "Search default currency...",
+  noCurrencyFound: "No currency found.",
+
+  // Converter
+  currencyConverter: "Currency Converter",
+  fiat: "Fiat",
+  bitcoin: "Bitcoin",
+  convertingFiatToBtc: "Converting Fiat to Bitcoin",
+  convertingBtcToFiat: "Converting Bitcoin to Fiat",
+  sats: "sats",
+  btc: "BTC",
+  satoshis: "Satoshis (sats)",
+  bitcoinUnit: "Bitcoin (BTC)",
+
+  // Settings
+  settings: "Settings",
+  display: "Display",
+  bitcoinOnlyMode: "Bitcoin-only Mode",
+  highlightBitcoin: "Highlight Bitcoin",
+  saylorMode: "Saylor Mode ⚡",
+  whatIsSaylorMode: "What is Saylor Mode?",
+  saylorModeTooltip: "Automatically enabled when Saylor Mode and Bitcoin-only mode are both active",
+  denomination: "Denomination",
+  dynamic: "Dynamic",
+  dynamicBtcSatsTooltip: "Shows BTC for prices ≥0.01 BTC, sats otherwise.",
+  advancedSettings: "Settings",
+
+  // Call To Action
+  subscribeToBitcoinBrief: "Subscribe to Bitcoin Brief",
+  lightMode: "Light Mode",
+  systemDefault: "System Default",
+  darkMode: "Dark Mode",
+
+  // Footer
+  enabledOnThisSite: "Enabled on this site",
+  disabledOnThisSite: "Disabled on this site",
+  privacy: "Privacy",
+  feedback: "Feedback",
+
+  // Saylor Mode Overlay
+  saylorModeTitle: "SAYLOR MODE",
+  saylorModeSubtitle: "Reprices everything for $21M per bitcoin",
+  learnMore: "Learn more",
+  continue: "CONTINUE",
+
+  // Options Page
+  optionsTitle: "Settings",
+  loadingOptions: "Loading...",
+  defaultCurrencyLabel: "Default Currency",
+  bitcoinUnitLabel: "Bitcoin Unit",
+  satsOption: "Satoshis",
+  btcOption: "Bitcoin",
+  dynamicOption: "Dynamic",
+  displayModeLabel: "Display Mode",
+  dualDisplayOption: "Dual Display",
+  bitcoinOnlyOption: "Bitcoin Only",
+  themeLabel: "Theme",
+  systemOption: "System",
+  lightOption: "Light",
+  darkOption: "Dark",
+  highlightBitcoinLabel: "Highlight Bitcoin values",
+  highlightMandatoryTooltip: "* Auto-enabled with Saylor Mode + Bitcoin-only",
+  saveButton: "Save Settings",
+  saveSuccess: "Saved!",
+  disabledSitesTitle: "Disabled Sites",
+  addSiteButton: "Add",
+  noDisabledSites: "No disabled sites",
+  newsletterTitle: "Bitcoin Brief Newsletter",
+  newsletterDescription: "Get Bitcoin updates and market insights from TFTC.",
+  subscribeButton: "Subscribe",
+};

--- a/extension/shared/src/locales/pt.ts
+++ b/extension/shared/src/locales/pt.ts
@@ -1,0 +1,83 @@
+export const translations = {
+  // Header
+  opportunityCost: "Custo de Oportunidade",
+  linkCopied: "Link copiado",
+  copyLink: "Copiar link",
+
+  // Live Price
+  bitcoinPrice: "Preço do Bitcoin:",
+  loading: "Carregando...",
+  error: "Erro",
+  lastUpdated: "Última atualização",
+  changeDefaultCurrency: "Mudar moeda padrão",
+  searchDefaultCurrency: "Buscar moeda padrão...",
+  noCurrencyFound: "Nenhuma moeda encontrada.",
+
+  // Converter
+  currencyConverter: "Conversor de Moeda",
+  fiat: "Fiat",
+  bitcoin: "Bitcoin",
+  convertingFiatToBtc: "Convertendo Fiat para Bitcoin",
+  convertingBtcToFiat: "Convertendo Bitcoin para Fiat",
+  sats: "sats",
+  btc: "BTC",
+  satoshis: "Satoshis (sats)",
+  bitcoinUnit: "Bitcoin (BTC)",
+
+  // Settings
+  settings: "Configurações",
+  display: "Exibição",
+  bitcoinOnlyMode: "Modo Bitcoin Only",
+  highlightBitcoin: "Destacar Bitcoin",
+  saylorMode: "Modo Saylor ⚡",
+  whatIsSaylorMode: "O que é o Modo Saylor?",
+  saylorModeTooltip: "Ativado automaticamente quando o Modo Saylor e o Modo Apenas Bitcoin estão ativos",
+  denomination: "Denominação",
+  dynamic: "Dinâmico",
+  dynamicBtcSatsTooltip: "Mostra BTC para preços ≥0.01 BTC, e sats para os demais.",
+  advancedSettings: "Configurações",
+
+  // Call To Action
+  subscribeToBitcoinBrief: "Assine a Bitcoin Brief",
+  lightMode: "Modo Claro",
+  systemDefault: "Padrão do Sistema",
+  darkMode: "Modo Escuro",
+
+  // Footer
+  enabledOnThisSite: "Habilitado neste site",
+  disabledOnThisSite: "Desabilitado neste site",
+  privacy: "Privacidade",
+  feedback: "Feedback",
+
+  // Saylor Mode Overlay
+  saylorModeTitle: "MODO SAYLOR",
+  saylorModeSubtitle: "Reprecifica tudo para $21M por bitcoin",
+  learnMore: "Saiba mais",
+  continue: "CONTINUAR",
+
+  // Options Page
+  optionsTitle: "Configurações",
+  loadingOptions: "Carregando...",
+  defaultCurrencyLabel: "Moeda Padrão",
+  bitcoinUnitLabel: "Unidade Bitcoin",
+  satsOption: "Satoshis",
+  btcOption: "Bitcoin",
+  dynamicOption: "Dinâmico",
+  displayModeLabel: "Modo de Exibição",
+  dualDisplayOption: "Exibição Dupla",
+  bitcoinOnlyOption: "Apenas Bitcoin",
+  themeLabel: "Tema",
+  systemOption: "Sistema",
+  lightOption: "Claro",
+  darkOption: "Escuro",
+  highlightBitcoinLabel: "Destacar valores em Bitcoin",
+  highlightMandatoryTooltip: "* Ativado automaticamente com Modo Saylor + Apenas Bitcoin",
+  saveButton: "Salvar Configurações",
+  saveSuccess: "Salvo!",
+  disabledSitesTitle: "Sites Desabilitados",
+  addSiteButton: "Adicionar",
+  noDisabledSites: "Nenhum site desabilitado",
+  newsletterTitle: "Newsletter Bitcoin Brief",
+  newsletterDescription: "Receba atualizações sobre Bitcoin e análises de mercado da TFTC.",
+  subscribeButton: "Inscrever-se",
+};


### PR DESCRIPTION
**Description:**

Hi there!

This PR introduces the complete Portuguese (pt-BR) localization for the extension, making it more accessible to a large audience.

To achieve this, I've implemented a lightweight internationalization (i18n) structure that makes future translations much easier. Instead of just hardcoding the Portuguese strings, I've:

1.  **Extracted** all hardcoded UI strings from the popup and options pages.
2.  **Created** a new `src/locales` directory with `en.ts` (for the original English text) and `pt.ts` (for the new translation).
3.  **Updated** the React components to dynamically load strings based on the browser's language (`browser.i18n.getUILanguage()`).

This approach not only adds the pt-BR translation but also provides a clean and scalable foundation for adding more languages in the future.

I've tested the build locally on Chrome, and everything is working as expected.

### Screenshot

Here's a look at the translated UI in action:

<img width="323" height="421" alt="custo-de-oportunidade" src="https://github.com/user-attachments/assets/0afeee19-29f5-45d1-b84b-8a3ee9e1ec38" />
<img width="647" height="840" alt="options" src="https://github.com/user-attachments/assets/074c8fc5-2e11-4aee-bc3f-71a5552744c5" />

!Screenshot of the extension in Portuguese

Hope this helps the project! Let me know if any changes are needed.

Cheers!
